### PR TITLE
Add squad AI scaffolding

### DIFF
--- a/.github/workflows/ue-plugin-ci.yml
+++ b/.github/workflows/ue-plugin-ci.yml
@@ -1,41 +1,40 @@
-name: Build-Plugin-Win64
+name: Build-Plugin
 
 on:
-  push: { branches: [main, dev] }
+  push:
+    branches: [main, dev]
   pull_request:
 
 jobs:
   build:
-    runs-on: windows-2022
+    strategy:
+      matrix:
+        platform: [windows-2022, ubuntu-22.04]
+    runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
         with:
           lfs: true
 
-      - name: Setup MSVC
+      - name: Setup Toolchain
+        if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Cache UE binaries
         uses: actions/cache@v4
         with:
-          path: "C:/Program Files/Epic Games/UE_5.4"
-          key: UE5.4-win64
-
-      - name: Generate project files
-        run: |
-          & "C:/Program Files/Epic Games/UE_5.4/Engine/Build/BatchFiles/RunUAT.bat" \
-            -ScriptsForProject=`"${{ github.workspace }}/DummyProject/Dummy.uproject`" \
-            GenerateProjectFiles -projectfiles
+          path: ${{ runner.os == 'Windows' && 'C:/Program Files/Epic Games/UE_5.4' || '/opt/UE_5.4' }}
+          key: UE5.4-${{ runner.os }}
 
       - name: Build plugin
         run: |
-          & "C:/Program Files/Epic Games/UE_5.4/Engine/Build/BatchFiles/RunUAT.bat" BuildPlugin ^
-             -Plugin="${{ github.workspace }}/Plugins/SquadAI/SquadAI.uplugin" ^
-             -Package="${{ github.workspace }}/PluginPackages/SquadAI" ^
-             -TargetPlatforms=Win64
+          ${{ runner.os == 'Windows' && '& "C:/Program Files/Epic Games/UE_5.4/Engine/Build/BatchFiles/RunUAT.bat"' || '/opt/UE_5.4/Engine/Build/BatchFiles/RunUAT.sh' }} BuildPlugin \
+            -Plugin="${{ github.workspace }}/Plugins/SquadAI/SquadAI.uplugin" \
+            -Package="${{ github.workspace }}/PluginPackages/SquadAI-${{ runner.os }}" \
+            -TargetPlatforms=${{ runner.os == 'Windows' && 'Win64' || 'Linux' }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: SquadAI-win64
-          path: PluginPackages/SquadAI
+          name: SquadAI-${{ runner.os }}
+          path: PluginPackages/SquadAI-${{ runner.os }}

--- a/Docs/BlueprintPrompts.md
+++ b/Docs/BlueprintPrompts.md
@@ -1,0 +1,33 @@
+# Blueprint Prompts
+
+These prompts can be fed into the Blueprint generator to create helper functions.
+
+## HandleUnderFire (AIController)
+```
+CreateFunction HandleUnderFire
+Parent BP_SquadAIController
+Node1 Set IsUnderFire=true
+Node2 Set ThreatLocation=InStimulus.Location
+Node3 Call FindCoverLocation Source=Self ThreatLoc=ThreatLocation -> CoverLoc
+Node4 AI_MoveTo Pawn=ControlledPawn Destination=CoverLoc AcceptanceRadius=60
+Node5 RetriggerableDelay 3
+Node6 Set IsUnderFire=false
+```
+
+## InitializeAI (Character)
+```
+CreateFunction InitializeAI
+Parent BP_SquadCharacter
+Node1 Call SpawnDefaultController
+Node2 Call SetupHealth
+Node3 Call RegisterWithSquadManager Self
+Node4 PrintString "Init OK"
+```
+
+## FindCoverLocation (AIController, pure)
+```
+CreateFunction FindCoverLocation
+Parent BP_SquadAIController
+Node1 EQS_RunQuery Template=EQS_FindCover Querier=ControlledPawn ThreatLoc=ThreatLocation
+Node2 ReturnResult ResultLocation
+```

--- a/Plugins/SquadAI/Content/AI/BT_SquadLogic.json
+++ b/Plugins/SquadAI/Content/AI/BT_SquadLogic.json
@@ -1,0 +1,53 @@
+{
+  "Type": "BehaviorTree",
+  "RootNode": {
+    "Class": "BTComposite_Selector",
+    "Children": [
+      {
+        "Class": "BTComposite_Sequence",
+        "Name": "ReactToFire",
+        "Decorators": [
+          {
+            "Class": "BTDecorator_Blackboard",
+            "BlackboardKey": "IsUnderFire",
+            "NotifyObserver": "ValueChange",
+            "ObservedKey": "IsUnderFire",
+            "Operation": "IsSet"
+          },
+          {
+            "Class": "BTDecorator_Cooldown",
+            "Cooldown": 3.0
+          }
+        ],
+        "Children": [
+          {
+            "Class": "BTTask_MoveTo",
+            "BlackboardKey": "ThreatLocation"
+          }
+        ]
+      },
+      {
+        "Class": "BTComposite_Sequence",
+        "Name": "NormalPatrol",
+        "Decorators": [
+          {
+            "Class": "BTDecorator_Blackboard",
+            "BlackboardKey": "IsUnderFire",
+            "Operation": "IsNotSet"
+          }
+        ],
+        "Children": [
+          {
+            "Class": "BTTask_MoveTo",
+            "BlackboardKey": "Waypoint"
+          },
+          {
+            "Class": "BTTask_Wait",
+            "RandomDeviation": 2.0,
+            "WaitTime": 2.0
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/Plugins/SquadAI/Content/AI/EQS_FindCover.json
+++ b/Plugins/SquadAI/Content/AI/EQS_FindCover.json
@@ -1,0 +1,19 @@
+{
+  "Name": "EQS_FindCover",
+  "Steps": [
+    {
+      "Generator": "NavmeshPoints",
+      "Radius": 1200
+    },
+    {
+      "Test": "TraceFromThreat",
+      "Weight": 3,
+      "Prefer": "Hidden"
+    },
+    {
+      "Test": "Distance",
+      "Weight": 1,
+      "PreferredRange": [400, 800]
+    }
+  ]
+}

--- a/Plugins/SquadAI/Source/SquadAI/Private/SquadAIController.cpp
+++ b/Plugins/SquadAI/Source/SquadAI/Private/SquadAIController.cpp
@@ -1,13 +1,27 @@
 #include "SquadAIController.h"
 #include "BehaviorTree/BehaviorTree.h"
+#include "Perception/AIPerceptionComponent.h"
+#include "BehaviorTree/BlackboardComponent.h"
 
 ASquadAIController::ASquadAIController()
 {
+    PerceptionComp = CreateDefaultSubobject<UAIPerceptionComponent>(TEXT("PerceptionComp"));
+    SetPerceptionComponent(*PerceptionComp);
 }
 
-void ASquadAIController::OnUnderFire(const FAIStimulus& Stimulus)
+void ASquadAIController::OnPerceptionUpdated(const TArray<AActor*>& UpdatedActors)
 {
-    // TODO: React to gunfire stimulus
+    for (AActor* Actor : UpdatedActors)
+    {
+        FAIStimulus Stimulus;
+        if (PerceptionComp->GetActorsPerception(Actor, Stimulus))
+        {
+            if (Stimulus.Tag == FName("Gunfire") && Stimulus.WasSuccessfullySensed())
+            {
+                HandleUnderFire(Stimulus);
+            }
+        }
+    }
 }
 
 void ASquadAIController::OnPossess(APawn* InPawn)
@@ -17,9 +31,35 @@ void ASquadAIController::OnPossess(APawn* InPawn)
     {
         RunBehaviorTree(SquadBehaviour);
     }
+    if (PerceptionComp)
+    {
+        PerceptionComp->OnPerceptionUpdated.AddDynamic(this, &ASquadAIController::OnPerceptionUpdated);
+    }
 }
 
 void ASquadAIController::FindAndMoveToCover(const FVector& ThreatLocation)
 {
     // TODO: Implement EQS query to select best cover location
+}
+
+void ASquadAIController::HandleUnderFire(const FAIStimulus& Stimulus)
+{
+    if (UBlackboardComponent* BB = GetBlackboardComponent())
+    {
+        BB->SetValueAsVector(BB_ThreatLoc, Stimulus.StimulusLocation);
+        BB->SetValueAsBool(BB_IsUnderFire, true);
+    }
+    FindAndMoveToCover(Stimulus.StimulusLocation);
+    GetWorldTimerManager().SetTimerForNextTick([this]()
+    {
+        GetWorldTimerManager().SetTimer(ClearUnderFireHandle, this, &ASquadAIController::ClearUnderFire, 3.0f, false);
+    });
+}
+
+void ASquadAIController::ClearUnderFire()
+{
+    if (UBlackboardComponent* BB = GetBlackboardComponent())
+    {
+        BB->SetValueAsBool(BB_IsUnderFire, false);
+    }
 }

--- a/Plugins/SquadAI/Source/SquadAI/Private/SquadCharacter.cpp
+++ b/Plugins/SquadAI/Source/SquadAI/Private/SquadCharacter.cpp
@@ -1,0 +1,42 @@
+#include "SquadCharacter.h"
+#include "Components/SphereComponent.h"
+
+ASquadCharacter::ASquadCharacter()
+{
+    PrimaryActorTick.bCanEverTick = false;
+
+    CoverDebugSphere = CreateDefaultSubobject<USphereComponent>(TEXT("CoverDebugSphere"));
+    CoverDebugSphere->SetupAttachment(RootComponent);
+    CoverDebugSphere->SetSphereRadius(30.f);
+    CoverDebugSphere->SetHiddenInGame(false);
+
+    MaxHealth = 100.f;
+    CurrentHealth = MaxHealth;
+}
+
+void ASquadCharacter::BeginPlay()
+{
+    Super::BeginPlay();
+    SetupHealth();
+}
+
+void ASquadCharacter::SetupHealth()
+{
+    CurrentHealth = MaxHealth;
+}
+
+float ASquadCharacter::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser)
+{
+    const float ActualDamage = Super::TakeDamage(DamageAmount, DamageEvent, EventInstigator, DamageCauser);
+    CurrentHealth -= ActualDamage;
+    if (CurrentHealth <= 0.f)
+    {
+        OnHealthZero();
+    }
+    return ActualDamage;
+}
+
+void ASquadCharacter::OnHealthZero()
+{
+    Destroy();
+}

--- a/Plugins/SquadAI/Source/SquadAI/Public/SquadAIController.h
+++ b/Plugins/SquadAI/Source/SquadAI/Public/SquadAIController.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "AIController.h"
 #include "Perception/AIPerceptionTypes.h"
+#include "Perception/AIPerceptionComponent.h"
+#include "BehaviorTree/BehaviorTree.h"
+#include "TimerManager.h"
 #include "SquadAIController.generated.h"
 
 UCLASS()
@@ -11,17 +14,24 @@ class ASquadAIController : public AAIController
 public:
     ASquadAIController();
 
-    UFUNCTION()
-    void OnUnderFire(const FAIStimulus& Stimulus);
-
 protected:
     virtual void OnPossess(APawn* InPawn) override;
+    UFUNCTION()
+    void OnPerceptionUpdated(const TArray<AActor*>& UpdatedActors);
+
+    void FindAndMoveToCover(const FVector& ThreatLocation);
 
 private:
-    void FindAndMoveToCover(const FVector& ThreatLocation);
+    void HandleUnderFire(const FAIStimulus& Stimulus);
+    void ClearUnderFire();
 
     UPROPERTY(EditDefaultsOnly, Category = "AI")
     UBehaviorTree* SquadBehaviour;
+
+    UPROPERTY(VisibleAnywhere, Category = "AI")
+    UAIPerceptionComponent* PerceptionComp;
+
+    FTimerHandle ClearUnderFireHandle;
 
     FName BB_ThreatLoc = "ThreatLocation";
     FName BB_IsUnderFire = "IsUnderFire";

--- a/Plugins/SquadAI/Source/SquadAI/Public/SquadCharacter.h
+++ b/Plugins/SquadAI/Source/SquadAI/Public/SquadCharacter.h
@@ -1,0 +1,31 @@
+#pragma once
+#include "GameFramework/Character.h"
+#include "SquadCharacter.generated.h"
+
+UCLASS()
+class ASquadCharacter : public ACharacter
+{
+    GENERATED_BODY()
+
+public:
+    ASquadCharacter();
+
+    virtual float TakeDamage(float DamageAmount, struct FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser) override;
+
+protected:
+    virtual void BeginPlay() override;
+
+    void SetupHealth();
+
+    UFUNCTION()
+    void OnHealthZero();
+
+    UPROPERTY(EditAnywhere, Category="Squad")
+    float MaxHealth;
+
+    UPROPERTY(VisibleAnywhere, Category="Squad")
+    float CurrentHealth;
+
+    UPROPERTY(VisibleAnywhere)
+    class USphereComponent* CoverDebugSphere;
+};

--- a/Plugins/SquadAI/Source/SquadAI/SquadAI.Build.cs
+++ b/Plugins/SquadAI/Source/SquadAI/SquadAI.Build.cs
@@ -10,7 +10,8 @@ public class SquadAI : ModuleRules
         {
             "Core", "CoreUObject", "Engine",
             "AIModule",
-            "GameplayTasks"
+            "GameplayTasks",
+            "NavigationSystem"
         });
     }
 }


### PR DESCRIPTION
## Summary
- extend module dependencies
- flesh out AI controller with perception handling
- add basic squad character class
- provide Behavior Tree and EQS JSON descriptors
- update CI workflow to build on Windows and Linux
- document Blueprint generation prompts

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_68450392f7308321a0862ef6335bd202