### PR TITLE
Fix CI path

### DIFF
--- a/.github/workflows/ue-plugin-ci.yml
+++ b/.github/workflows/ue-plugin-ci.yml
@@ -7,34 +7,31 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        platform: [windows-2022, ubuntu-22.04]
-    runs-on: ${{ matrix.platform }}
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:
           lfs: true
 
       - name: Setup Toolchain
-        if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Cache UE binaries
         uses: actions/cache@v4
         with:
-          path: ${{ runner.os == 'Windows' && 'C:/Program Files/Epic Games/UE_5.4' || '/opt/UE_5.4' }}
-          key: UE5.4-${{ runner.os }}
+          path: 'C:/Program Files/Epic Games/UE_5.4'
+          key: UE5.4-win64
 
       - name: Build plugin
+        shell: powershell
         run: |
-          ${{ runner.os == 'Windows' && '& "C:/Program Files/Epic Games/UE_5.4/Engine/Build/BatchFiles/RunUAT.bat"' || '/opt/UE_5.4/Engine/Build/BatchFiles/RunUAT.sh' }} BuildPlugin \
-            -Plugin="${{ github.workspace }}/Plugins/SquadAI/SquadAI.uplugin" \
-            -Package="${{ github.workspace }}/PluginPackages/SquadAI-${{ runner.os }}" \
-            -TargetPlatforms=${{ runner.os == 'Windows' && 'Win64' || 'Linux' }}
+          & "C:\Program Files\Epic Games\UE_5.4\Engine\Build\BatchFiles\RunUAT.bat" BuildPlugin `
+            -Plugin="${{ github.workspace }}/Plugins/SquadAI/SquadAI.uplugin" `
+            -Package="${{ github.workspace }}/PluginPackages/SquadAI" `
+            -TargetPlatforms=Win64
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: SquadAI-${{ runner.os }}
-          path: PluginPackages/SquadAI-${{ runner.os }}
+          name: SquadAI-win64
+          path: PluginPackages/SquadAI

--- a/BuildAll.ps1
+++ b/BuildAll.ps1
@@ -1,5 +1,5 @@
 param([string]$UE="C:\Program Files\Epic Games\UE_5.4")
 & "$UE\Engine\Build\BatchFiles\RunUAT.bat" BuildPlugin `
    -Plugin="$PSScriptRoot\Plugins\SquadAI\SquadAI.uplugin" `
-   -Package="$PSScriptRoot\Packages\SquadAI" -TargetPlatforms=Win64,Lin64
+   -Package="$PSScriptRoot\Packages\SquadAI" -TargetPlatforms=Win64
 

--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@ For a detailed blueprint on structuring a plugin repository with Git and GitHub,
 
 The repository includes a small PowerShell script, `BuildAll.ps1`, that wraps
 Unreal's `RunUAT` automation tool. It packages the plugin so it can be dropped
-into any project. The script targets both Windows and Linux by default.
+into any project. The script targets only Windows by default and expects Unreal
+Engine to be installed under `C:\Program Files\Epic Games\UE_5.4` (override
+with the `-UE` parameter if needed).
 
 ```
 PS> ./BuildAll.ps1
 ```
 
 After the command finishes you will find the packaged plugin under
-`Packages/SquadAI`. The generated archive contains builds for `Win64` and
-`Linux`, allowing you to test or distribute the plugin on either platform.
+`Packages/SquadAI`. The generated archive contains a build for `Win64`.


### PR DESCRIPTION
## Summary
- build plugin only for Win64
- update docs for Win64-only packaging
- restrict CI to Windows
- fix path quoting in CI workflow

## Testing
- `pwsh -Command ./BuildAll.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b4b1d132883218bdc3cf9768d5304